### PR TITLE
fix: resolve country selector dropdown issue inside dialog by adding modal prop to Popover

### DIFF
--- a/src/components/ui/CountrySelector/countrySelector.tsx
+++ b/src/components/ui/CountrySelector/countrySelector.tsx
@@ -93,7 +93,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({
           >
             {label}
           </label>
-          <Popover open={open} onOpenChange={setOpen}>
+          <Popover modal open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"


### PR DESCRIPTION
Popover inside the AlertDialog was being clipped or not clickable due to stacking context and overflow issues.
Fixed by enabling modal mode, which renders the dropdown in a portal outside the dialog's DOM.